### PR TITLE
Fixes timer initial display when using resolveUrl

### DIFF
--- a/src/components/Timer.js
+++ b/src/components/Timer.js
@@ -24,8 +24,12 @@ class Timer extends Component {
     }
 
     render() {
-        let { duration, currentTime, className, style } = this.props;
+        let { duration, currentTime, className, style, soundCloudAudio } = this.props;
         let classNames = ClassNames('sb-soundplayer-timer', className);
+        
+        if (!duration && soundCloudAudio.duration) {
+            duration = soundCloudAudio.duration
+        }
 
         return (
             <div className={classNames} style={style}>


### PR DESCRIPTION
When using `SoundPlayerContainer` and passing in the `resolveUrl` prop instead of `streamUrl`, the `Timer` component does not display the full duration of the track when its rendered. The duration only gets filled after the track is played. This PR fixes the issue by tapping into the `soundCloudAudio` instance so it can render the tracks full duration even before its played.
